### PR TITLE
Zephyr fixes for K64F, 6LOWPAN ping and nRF52840 progressive erase fixes

### DIFF
--- a/arch/arm/core/cortex_m/mpu/nxp_mpu.c
+++ b/arch/arm/core/cortex_m/mpu/nxp_mpu.c
@@ -327,9 +327,16 @@ static int _mpu_configure_dynamic_mpu_regions(const struct k_mem_partition
 {
 	/* Reset MPU regions inside which dynamic memory regions may
 	 * be programmed.
+	 *
+	 * Re-programming these regions will temporarily leave memory areas
+	 * outside all MPU regions.
+	 * This might trigger memory faults if ISRs occurring during
+	 * re-programming perform access in those areas.
 	 */
+	arm_core_mpu_disable();
 	_region_init(mpu_config.sram_region, (const struct nxp_mpu_region *)
 		&mpu_config.mpu_regions[mpu_config.sram_region]);
+	arm_core_mpu_enable();
 
 	u32_t mpu_reg_index = static_regions_num;
 

--- a/subsys/dfu/boot/mcuboot.c
+++ b/subsys/dfu/boot/mcuboot.c
@@ -509,12 +509,6 @@ int boot_erase_img_bank(u8_t area_id)
 #ifdef CONFIG_FLASH_PAGE_LAYOUT
 int boot_invalidate_slot1(void)
 {
-	static const u32_t zero_magic[4] = {
-		0x00000000,
-		0x00000000,
-		0x00000000,
-		0x00000000,
-	};
 	struct flash_pages_info magic_info;
 	const struct flash_area *fa;
 	struct device *dev;
@@ -543,8 +537,6 @@ int boot_invalidate_slot1(void)
 	if (rc != 0) {
 		goto out;
 	}
-
-	rc = flash_area_write(fa, magic_off, zero_magic, sizeof(zero_magic));
 
 out:
 	flash_area_close(fa);

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -335,6 +335,7 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 
 	net_pkt_set_data(pkt, &icmpv6_access);
 
+	net_pkt_cursor_init(pkt);
 	net_ipv6_finalize(pkt, IPPROTO_ICMPV6);
 
 	NET_DBG("Sending ICMPv6 Echo Request type %d from %s to %s",


### PR DESCRIPTION
5 fixes for:
- Fix MPU bug causing random K64F reboots
- Fix flash driver semaphore issue in mcuboot where CONFIG_MULTITHREADING=n on K64F
- Fix ping issue for 6lowpan networks
- Re-introduce the changes make boot_flag_write() more generic
- Fixup boot_invalidate_slot1() so that mcuboot upgrades will trigger correctly